### PR TITLE
IN-17502 - update 2022 toolbox support items into ug page

### DIFF
--- a/Common/Essential-Studio/Utilities.md
+++ b/Common/Essential-Studio/Utilities.md
@@ -320,6 +320,7 @@ To launch Toolbox configuration utility, follow the steps given below:
    * Install VS2015 – Configures Framework 4.6 Syncfusion controls in VS 2015 toolbox.
    * Install VS2017 – Configures Framework 4.6 Syncfusion controls in VS 2017 toolbox.
    * Install VS2019 – Configures Framework 4.6 Syncfusion controls in VS 2019 toolbox
+   * Install VS2022 – Configures Framework 4.6 Syncfusion controls in VS 2022 toolbox
    
     N> You can also configure Syncfusion controls from a lower version Framework assembly to higher version of Visual Studio.
    
@@ -331,7 +332,11 @@ To launch Toolbox configuration utility, follow the steps given below:
    N> * You must reset the toolbox, when the installed controls are not reflected properly in the Toolbox.
 
    * This tool configures only the controls that are located under {Installed Location}\Assemblies\{Framework version}.
-   
+
+### Configuring toolbox in Visual Studio 2022   
+
+From 2021 Volume 3, Syncfusion started providing toolbox support for .NET framework in Visual Studio 2022 Toolbox. After installing the Syncfusion product installer, Syncfusion controls will be automatically configured in the Visual Studio 2022 toolbox for WPF, Windows, and ASP.NET WebForms projects.
+
 ### Configuring toolbox for WPF .NET 5.0 projects
 
 From 2021 Volume 1, Syncfusion started providing toolbox support for WPF .NET 5.0 framework in Visual Studio 2019. Syncfusion controls will be automatically configured in the Visual Studio 2019 toolbox for WPF .NET 5.0 project, after installing the Syncfusion WPF installer.


### PR DESCRIPTION
| Title | Description |
| -------- | -------- |
|**Task Link** |  https://syncfusion.atlassian.net/browse/IN-17502  |
|**Feature description** | <ol><b>We have provided VS2022 support on the 2021 Vol 3 Main release. Need to update these details in the following common UG pages and the required individual platform pages.<b></ol>|
|**Analysis and design**  | <ul><li>No design changes required</li></ul>|
| **Solution description**   |  <ol><b><li>Added Toolbox support for Visula Studio 2022 content in WPF,Windows, ASP.NET and Common UG</li><li>.NET 6.0 support changes added for WPF</li><b></ol>|
|  **Output screenshots** | N/A |
| **Areas affected and ensured** | No other areas are affected|
| **Test cases**   | None|
| **Testbed sample location** | N/A |
| **Additional CheckList**  |<ul><li>Did you run the automation against your fix? No</li><li>Is there any API name change?N/A</li><li>Is there any existing behavior change of other features due to this code change? No.</li><li>Does your new code introduce new warnings or binding errors? No.</li><li>Does your code pass all FxCop and StyleCop rules? N/A.</li><li> Did you record this case in the unit test or UI test? N/A</li></ul>   |