### PR TITLE
Reverting the trademark symbol in unwanted places

### DIFF
--- a/Common/Essential-Studio/licensing/how-to-register-in-an-application.md
+++ b/Common/Essential-Studio/licensing/how-to-register-in-an-application.md
@@ -236,7 +236,7 @@ Register the license key in **App.xaml.cs** constructor before InitializeCompone
 {% highlight c# %}
 public App()
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 
 	this.InitializeComponent();

--- a/Common/Essential-Studio/licensing/how-to-register-in-an-application.md
+++ b/Common/Essential-Studio/licensing/how-to-register-in-an-application.md
@@ -47,7 +47,7 @@ N> If the **Application.Designer.vb** file is not included by default in the pro
 {% highlight c# %}
 static void Main()
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	
     Application.EnableVisualStyles();
@@ -59,7 +59,7 @@ static void Main()
 {% highlight vb %}
 Public Sub New()
 		MyBase.New(Global.Microsoft.VisualBasic.ApplicationServices.AuthenticationMode.Windows)
-		'Register Syncfusion<sup style="font-size:70%">&reg;</sup>  License
+		'Register Syncfusion License
 		Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY")
 		Me.IsSingleInstance = False
 		Me.EnableVisualStyles = True
@@ -79,7 +79,7 @@ public partial class App : Application
 {
 	public App()
 	{
-		//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+		//Register Syncfusion license
 		Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	}	
 } 
@@ -87,7 +87,7 @@ public partial class App : Application
 
 {% highlight vb %}
 Private Sub New()
-	'Register Syncfusion<sup style="font-size:70%">&reg;</sup>  License
+	'Register Syncfusion License
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY")
 End Sub
 {% endhighlight %}
@@ -102,7 +102,7 @@ Register the license key in Application_Start method of **Global.asax.cs/Global.
 {% highlight c# %}
 void Application_Start(object sender, EventArgs e)
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	
 	// Code that runs on application startup
@@ -134,7 +134,7 @@ Register the license key in Configure method of **Startup.cs**
 // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	
 	loggerFactory.AddConsole(Configuration.GetSection("Logging"));
@@ -157,7 +157,7 @@ Register the license key in Configure method of **Startup.cs**
 // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 {
-    //Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+    //Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	
     if (env.IsDevelopment())
@@ -194,7 +194,7 @@ Register the license key in the **Program.cs** file if you created the Blazor se
 {% tabs %}
 {% highlight c# %}
 var app = builder.Build();
-//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+//Register Syncfusion license
 Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 
 // Configure the HTTP request pipeline.
@@ -217,7 +217,7 @@ Register the license key in main method of **Program.cs**
 using Syncfusion.Blazor;
 public static async Task Main(string[] args) 
 { 
-    //Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license 
+    //Register Syncfusion license 
     Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");  
     var builder = WebAssemblyHostBuilder.CreateDefault(args); 
     builder.RootComponents.Add<App>("app");                               
@@ -246,7 +246,7 @@ public App()
 
 {% highlight vb %}
 Public Sub New()
-	'Register Syncfusion<sup style="font-size:70%">&reg;</sup>  License
+	'Register Syncfusion License
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY")
 End Sub
 
@@ -268,7 +268,7 @@ public partial class App : Application
 {
 	public App()
 	{
-		//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+		//Register Syncfusion license
 		Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	}	
 } 
@@ -284,7 +284,7 @@ Register the license key in **App.xaml.cs** constructor before InitializeCompone
 {% highlight c# %}
 public App()
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	
 	InitializeComponent();
@@ -307,7 +307,7 @@ If you are using **Prism Framework** in your application, register the license k
 {% highlight c# %}
 protected override async void OnInitialized()
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
     Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
  
     InitializeComponent();
@@ -325,7 +325,7 @@ Register the license key in **OnCreate** override method of your main activity c
 {% highlight c# %}
 protected override void OnCreate(Bundle savedInstanceState)
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 
 	base.OnCreate(savedInstanceState);
@@ -345,7 +345,7 @@ Register the license key in **FinishedLaunching** override method of **AppDelega
 {% highlight c# %}
 public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 
 	// create a new window instance based on the screen size
@@ -370,7 +370,7 @@ You can register the license key in **App.xaml.cs** constructor before Initializ
 {% highlight c# %}
 public App()
 {
-	//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license
+	//Register Syncfusion license
 	Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 	
 	InitializeComponent();
@@ -391,7 +391,7 @@ Register the license key in the **main method** of your example and import the â
 import 'package:syncfusion_flutter_core/core.dart';
 
 void main() { 
-// Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license 
+// Register Syncfusion license 
 SyncfusionLicense.registerLicense("YOUR LICENSE KEY"); 
 return runApp(MyApp()); 
 }
@@ -410,7 +410,7 @@ Import â€˜syncfusion.licensing' package and register the license key in the **ma
 import com.syncfusion.licensing.*;
 
 static void main() { 
-// Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license 
+// Register Syncfusion license 
 SyncfusionLicenseProvider.registerLicense("YOUR LICENSE KEY"); 
 }
 {% endhighlight %}
@@ -432,7 +432,7 @@ Register the license key by using **registerLicense** method after the [Syncfusi
 
 {% tabs %}
 {% highlight JS %}
-// Registering Syncfusion<sup style="font-size:70%">&reg;</sup>  license key
+// Registering Syncfusion license key
 ej.base.registerLicense('License Key');
 {% endhighlight %}
 {% endtabs %}
@@ -443,7 +443,7 @@ Register the license key at the entry point of the project before using the Sync
 
 {% tabs %}
 {% highlight JS %}
-// Registering Syncfusion<sup style="font-size:70%">&reg;</sup>  license key
+// Registering Syncfusion license key
 import { registerLicense } from '@syncfusion/ej2-base';
 
 registerLicense('License key');
@@ -463,7 +463,7 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 import { registerLicense } from '@syncfusion/ej2-base';
 
-// Registering Syncfusion<sup style="font-size:70%">&reg;</sup>  license key
+// Registering Syncfusion license key
 registerLicense('License Key');
 
 if (environment.production) {
@@ -488,7 +488,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { registerLicense } from '@syncfusion/ej2-base';
 
-// Registering Syncfusion<sup style="font-size:70%">&reg;</sup>  license key
+// Registering Syncfusion license key
 registerLicense('License Key');
 
 ReactDOM.render(
@@ -510,7 +510,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import { registerLicense } from '@syncfusion/ej2-base';
 
-// Registering Syncfusion<sup style="font-size:70%">&reg;</sup>  license key
+// Registering Syncfusion license key
 registerLicense('License Key');
 createApp(App).mount('#app')
 {% endhighlight %}

--- a/Common/Essential-Studio/licensing/licensing-faq/CI-license-validation.md
+++ b/Common/Essential-Studio/licensing/licensing-faq/CI-license-validation.md
@@ -135,7 +135,7 @@ pipeline {
 {% highlight c# %}
 using Syncfusion.Licensing;
 
-//Register Syncfusion<sup style="font-size:70%">&reg;</sup>  license key 
+//Register Syncfusion license key 
 Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("YOUR LICENSE KEY");
 
 //Validate the registered license key
@@ -172,7 +172,7 @@ N> * Place the license key between double quotes. Also, ensure that Syncfusion.L
 public void TestSyncfusionWPFLicense()
 {
 	var platform = Platform.WPF;
-	// Register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key
+	// Register the Syncfusion license key
 	SyncfusionLicenseProvider.RegisterLicense("Your License Key");
 
 	bool isValidLicense = SyncfusionLicenseProvider.ValidateLicense(platform, out var validationMessage);


### PR DESCRIPTION
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr;border-width:100%'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:7.7416in'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:7.7416in'>

<div style='direction:ltr'>


Title | Description
-- | --
Task Link | Revert   Syncfusion, Essential Studio trademark symbol in unwanted places
Feature description | Check   the occurrence of the trademark symbol and revert the changes in unwanted   places
Analysis and design | No   design changes required
Output screenshots | N/A
Areas affected and ensured | Changes   included in install-docs md files
Test cases |  
Testbed sample location | N/A
Additional Checklist | Did you run         the automation against your fix? No     Is there any API name change? N/A     Is there any existing behavior change of other features         due to this code change? No.     Does your new code introduce new warnings or binding         errors? No.     Does your code pass all FxCop and StyleCop rules? N/A.     Did you record this case in the unit test or UI test?         N/A



</div>

</div>

</div>

</div>

<!--EndFragment-->
</body>

</html>
